### PR TITLE
'hour12:false' shows midnight-1am as '24:00-24:59'

### DIFF
--- a/src/ui/TimeDisplay.tsx
+++ b/src/ui/TimeDisplay.tsx
@@ -25,7 +25,7 @@ export const TimeDisplay = () => {
       })}</div>
       <div class={styles.timeDisplay}>
         {time().toLocaleTimeString(undefined, {
-          hour12: false,
+          hourCycle: 'h23',
         })}
       </div>
     </Group>


### PR DESCRIPTION
Not sure of any use cases where this is applicable, but it was a Chromium thing some time ago. `hourCycle: 'h23'` forces 24hr time without the mysterious 24th hour.

http://jsfiddle.net/ashsimmonds/cqd5L1fn/1/